### PR TITLE
Default alphas for colors are your own alphas

### DIFF
--- a/src/Colorfy.jl
+++ b/src/Colorfy.jl
@@ -104,6 +104,8 @@ Default color alphas for `values`.
 """
 defaultalphas(values) = fill(1, length(values))
 
+defaultalphas(values::Values{Colorant}) = alpha.(values)
+
 """
     Colorfy.defaultcolorscheme(values)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,9 +65,14 @@ using Test
     colorfier = Colorfier(values, alphas=0.5)
     @test Colorfy.colors(colorfier) == coloralpha.(colors, 0.5)
 
+    values = colors
     alphas = rand(5)
-    colorfier = Colorfier(colors; alphas)
+    colorfier = Colorfier(values; alphas)
     @test Colorfy.colors(colorfier) == coloralpha.(colors, alphas)
+
+    values = coloralpha.(colors, alphas)
+    colorfier = Colorfier(values)
+    @test Colorfy.colors(colorfier) == values
   end
 
   @testset "colorfy" begin


### PR DESCRIPTION
This change avoids overriding color alphas with the general default alphas `alphas = fill(1, length(values))`.