### PR TITLE
Fix the implementation of color mapping for categorical values

### DIFF
--- a/ext/ColorfyCategoricalArraysExt.jl
+++ b/ext/ColorfyCategoricalArraysExt.jl
@@ -13,7 +13,7 @@ function Colorfy.getcolors(colorfier::Colorfier{<:Values{CategoricalValue}})
   values = Colorfy.values(colorfier)
   colorscheme = Colorfy.colorscheme(colorfier)
   nlevels = length(levels(values))
-  categcolors = colorscheme[range(0, 1, length=nlevels)]
+  categcolors = colorscheme[range(0, nlevels > 1 ? 1 : 0, length=nlevels)]
   categcolors[levelcode.(values)]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,6 +117,12 @@ using Test
     colors = categcolors[[2, 1, 1, 3, 1, 3, 3, 2, 1, 2]]
     @test colorfy(values) == coloralpha.(colors, 1)
     @test colorfy(values, alphas=0.5) == coloralpha.(colors, 0.5)
+
+    values = categorical([1, 1, 1, 1, 1], levels=[1])
+    categcolors = colorschemes[:viridis][range(0, 0, length=1)]
+    colors = categcolors[[1, 1, 1, 1, 1]]
+    @test colorfy(values) == coloralpha.(colors, 1)
+    @test colorfy(values, alphas=0.5) == coloralpha.(colors, 0.5)
   end
 
   @testset "Distributions" begin


### PR DESCRIPTION
For handle categorical arrays with 1 just level:
```
julia> categorical([1, 1, 1, 1, 1], levels=[1]) |> colorfy
ERROR: LoadError: ArgumentError: range(0.0, stop=1.0, length=1): endpoints differ
Stacktrace:
...
```