### PR TITLE
Fix StackOverflow in the `defaultalphas` function

### DIFF
--- a/src/Colorfy.jl
+++ b/src/Colorfy.jl
@@ -12,7 +12,6 @@ export Colorfier, colorfy
 
 # type alias to reduce typing
 const Values{T} = AbstractVector{<:T}
-const ValuesWithMissing{T} = AbstractVector{Union{Missing,T}}
 
 """
     Colorfier(values; [alphas, colorscheme, colorrange])
@@ -103,14 +102,17 @@ colorrange(colorfier::Colorfier) = colorfier.colorrange
 
 Default color alphas for `values`.
 """
-defaultalphas(values::Values) = fill(1, length(values))
-
-function defaultalphas(values::ValuesWithMissing)
+function defaultalphas(values::Values)
   minds = findall(ismissing, values)
   vinds = setdiff(1:length(values), minds)
-  valphas = defaultalphas(nonmissingvec(values[vinds]))
-  malpha = zero(eltype(valphas))
-  genvec(vinds, valphas, minds, malpha, length(values))
+
+  if isempty(minds)
+    fill(1, length(values))
+  else
+    valphas = defaultalphas(nonmissingvec(values[vinds]))
+    malpha = zero(eltype(valphas))
+    genvec(vinds, valphas, minds, malpha, length(values))
+  end
 end
 
 defaultalphas(values::Values{Colorant}) = alpha.(values)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,8 +79,7 @@ using Test
     colorfier = Colorfier(values)
     @test_throws ArgumentError Colorfy.colors(colorfier)
     values = Any[:red, :green, :blue] # vector with non-concrete eltype
-    alphas = rand(3)
-    colorfier = Colorfier(values; alphas)
+    colorfier = Colorfier(values)
     @test_throws ArgumentError Colorfy.colors(colorfier)
   end
 


### PR DESCRIPTION
The `defaultalphas` function is breaking when used with `Vetor{Any}`, this PR solves this problem.
MWE:
```julia
values = Any[:red, :green, :blue]
Colorfier(values)
```