### PR TITLE
Add colorscheme spec as vector of color strings

### DIFF
--- a/src/Colorfy.jl
+++ b/src/Colorfy.jl
@@ -22,7 +22,7 @@ Maps each value in `values` to a color. Colors can be obtained using the [`Color
 ## Options
 
 * `alphas` - Scalar or a vector of color alphas (default to `Colorfy.defaultalphas(values)`);
-* `colorscheme` - Scheme name or a `ColorSchemes.ColorScheme` object (default to `Colorfy.defaultcolorscheme(values)`);
+* `colorscheme` - Color scheme specification (default to `Colorfy.defaultcolorscheme(values)`);
 * `colorrange` - Tuple with minimum and maximum color values or a symbol that can be passed 
   to the `rangescale` argument of the `ColorSchemes.get` function (default to `Colorfy.defaultcolorrange(values)`);
 """
@@ -161,10 +161,11 @@ end
 """
     Colorfy.ascolorscheme(colorscheme)
 
-Valid `ColorScheme` object for a given `colorscheme`.
+Valid `ColorScheme` object for a given `colorscheme` specification.
 """
 ascolorscheme(colorscheme::Symbol) = colorschemes[colorscheme]
 ascolorscheme(colorscheme::AbstractString) = ascolorscheme(Symbol(colorscheme))
+ascolorscheme(colorscheme::AbstractVector) = ColorScheme([parse(Colorant, color) for color in colorscheme])
 ascolorscheme(colorscheme::ColorScheme) = colorscheme
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,6 +80,13 @@ using Test
     @test Colorfy.colorscheme(colorfier) == colorschemes[:grays]
     @test Colorfy.colorrange(colorfier) == :extrema
 
+    colorfier = Colorfier(values, colorscheme=["black", "white"])
+    @test Colorfy.values(colorfier) == values
+    @test Colorfy.alphas(colorfier) == fill(1, 10)
+    @test Colorfy.colorscheme(colorfier)[0.0] == colorant"black"
+    @test Colorfy.colorscheme(colorfier)[1.0] == colorant"white"
+    @test Colorfy.colorrange(colorfier) == :extrema
+
     colorfier = Colorfier(values, colorrange=(0.25, 0.75))
     @test Colorfy.values(colorfier) == values
     @test Colorfy.alphas(colorfier) == fill(1, 10)


### PR DESCRIPTION
This specification is already supported by Makie.jl and other plotting ecosystems.